### PR TITLE
Added Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: generic
+
 sudo: required
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,10 @@ services:
 
 install:
   - docker build -t genprog .
+
+# push stable builds to DockerHub
+after_success:
+  - if [ "${TRAVIS_BRANCH}" == "master" ]; then
+      docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}";
+      docker push squareslab/genprog
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+
+services:
+  - docker
+
+install:
+  - docker build -t genprog .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update && \
     echo "yes" >> /tmp/yes.txt && \
     opam init -y < /tmp/yes.txt && \
     opam install -y cil
-RUN ln -s /bin/bash /bin/sh
 
 RUN mkdir -p /opt/genprog
 WORKDIR /opt/genprog

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+MAINTAINER Chris Timperley "christimperley@googlemail.com"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      opam \
+      ocaml \
+      build-essential \
+      jq \
+      aspcud \
+      vim \
+      m4 && \
+    echo "yes" >> /tmp/yes.txt && \
+    opam init -y < /tmp/yes.txt && \
+    opam install -y cil
+RUN ln -s /bin/bash /bin/sh
+
+RUN mkdir -p /opt/genprog
+WORKDIR /opt/genprog
+ADD Makefile Makefile
+ADD src src

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,6 @@ RUN mkdir -p /opt/genprog
 WORKDIR /opt/genprog
 ADD Makefile Makefile
 ADD src src
+
+RUN eval $(opam config env) && \
+    make

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,12 @@ WORKDIR /opt/genprog
 ADD Makefile Makefile
 ADD src src
 
-RUN eval $(opam config env) && \
-    make
+RUN mkdir bin && \
+    eval $(opam config env) && \
+    make && \
+    mv src/repair bin/genprog && \
+    ln -s bin/genprog bin/repair && \
+    mv src/distserver bin/distserver && \
+    mv src/nhtserver bin/nhtserver
+
+ENV PATH "/opt/genprog/bin:${PATH}"


### PR DESCRIPTION
Installs `genprog` to `/opt/genprog` and updates `PATH`. Can be used in combination with BugZoo to conduct reproducible program repair studies.

Can be manually constructed via:

```
docker build -t genprog .
```

To check that everything was built correctly, you can spin up an interactive shell to poke `genprog`:

```
$ docker run --rm -it genprog
> genprog
GenProg Version: Wed Nov 29 19:30:23 UTC 2017

--allow-coverage-fail false
--appp 0.33333
--best-edit-rule "1 * fault_loc_weight ; 1 * max_test_fail_prob ; -1 * num_tests"
--best-test-rule "1 * test_fail_prob ; 1 * test_fail_count ; -1 * test_pass_count"
--clone-file ""
--compiler "gcc"
--compiler-command ""
--compiler-opts ""
--continue false
--coverage-info ""
--coverage-per-test false
--crossover "one"
--crossp 0.5
--delp 0.33333
--describe-machine false

...
```