### PR TITLE
Issue #9/#11

### DIFF
--- a/src/rep.ml
+++ b/src/rep.ml
@@ -1363,7 +1363,6 @@ class virtual ['gene,'code] cachingRepresentation = object (self : ('gene,'code)
       (e.g., [Unix.fork]), or if any of its own Unix system calls (such as
       [create_process] or [wait]) fail *)
   method test_cases tests =
-    self#updated () ; 
     if !fitness_in_parallel <= 1 || (List.length tests) < 2 then 
       (* If we're not going to run them in parallel, then just run them
        * sequentially in turn. *) 
@@ -1700,8 +1699,10 @@ class virtual ['gene,'code] cachingRepresentation = object (self : ('gene,'code)
             (* first, maybe we've reached the max number of evals *)
             if !num_fitness_samples <= count then
               let result = self#internal_check_test_cache test in
-                raise (Test_Result (get_opt result))
-            else
+              match result with
+              | Some(r) -> raise (Test_Result r)
+              | None -> ()
+              else
               (* second, maybe we'll get lucky with the persistent cache *) 
                 match self#internal_check_test_cache ~next test with
                 | Some(x,f) when count < (TestMap.find test (fst eval_count)) ->

--- a/src/rep.ml
+++ b/src/rep.ml
@@ -1159,8 +1159,8 @@ class virtual ['gene,'code] cachingRepresentation = object (self : ('gene,'code)
           abort "cachingRepresentation: sanity check failed (compilation)\n" 
         end ; 
         let tests =
-          (lmap (fun i -> (Positive i, (fun b -> not b))) (1 -- !pos_tests))
-            @ (lmap (fun i -> (Negative i, (fun b -> b))) (1 -- !neg_tests))
+          (lmap (fun i -> (Negative i, (fun b -> b))) (1 -- !neg_tests))
+            @ (lmap (fun i -> (Positive i, (fun b -> not b))) (1 -- !pos_tests))
         in
           liter (fun (t, failed) ->
             let name = test_name t in

--- a/src/rep.ml
+++ b/src/rep.ml
@@ -1363,6 +1363,7 @@ class virtual ['gene,'code] cachingRepresentation = object (self : ('gene,'code)
       (e.g., [Unix.fork]), or if any of its own Unix system calls (such as
       [create_process] or [wait]) fail *)
   method test_cases tests =
+    self#updated () ; 
     if !fitness_in_parallel <= 1 || (List.length tests) < 2 then 
       (* If we're not going to run them in parallel, then just run them
        * sequentially in turn. *) 


### PR DESCRIPTION
This is a pull request to resolve genprog-code issues #9 and #11.
This change specifically addresses `--search ga` configurations. It looks like the AST structure was not reset after initial test population, so that when the test cases were run, eval_count value was invalid in context. Specifically the root-cause for issue #9. In testing this change, I ran with `test/gcd-test` as well as a few local test scenarios - there seemed to be no unintended side-effects with this. 
I also ran it against issue #11 with the included test case from Padraic - and this change set resolved his failing signature as well. 
