### PR TITLE
Basic infrastructure to enable original CIL representation dump into "original.c" file

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -52,6 +52,7 @@ open Printf
 open Global
 open Population
 
+let rep_out = ref "original"
 let representation = ref ""
 let time_at_start = Unix.gettimeofday ()
 let describe_machine = ref false
@@ -81,6 +82,8 @@ let _ =
 
                "--rep", Arg.Set_string representation, "X representation X (c,txt,java)" ;
 
+               "--orig-rep-out", Arg.Set_string rep_out, "X Output filename to which to print initial representation" ;
+
                "--oracle-genome", Arg.Set_string oracle_genome,
                "X genome for oracle search, either string or binary file.";
 
@@ -97,6 +100,7 @@ let _ =
 let process base ext (rep :('a,'b) Rep.representation) =
   (* load the rep, either from a cache or from source *)
   rep#load base;
+  rep#print_original_src !rep_out;
   rep#debug_info () ;
 
   (* load incoming population, if specified.  We no longer have to do this

--- a/src/rep.ml
+++ b/src/rep.ml
@@ -490,6 +490,9 @@ class type ['gene,'code] representation = object('self_type)
 
       @return hashvalue for this variant.*)
   method hash : unit -> int
+
+  method print_original_src : string -> unit
+
 end
 
 (** Test name to string *)
@@ -1236,6 +1239,19 @@ class virtual ['gene,'code] cachingRepresentation = object (self : ('gene,'code)
     | Some(source_names) -> source_names
     | None -> []
   (**/**)
+
+
+  method print_original_src fname = 
+    let original_filename = (fname) ^ if (!Global.extension <> "")
+        then !Global.extension
+        else "" in
+      self#output_source original_filename ; 
+	(*  note from pdreiter:
+	   clearing already_sourced to ensure that the outputted file isn't removed 
+	   when cleanup () is called
+	*)
+    already_sourced := None ; 
+
 
   (** ignores the return values of the unix system calls it uses, namely [system]
       and [unlink], and thus will fail silently if they do *)


### PR DESCRIPTION
So I have a need to create a diff patch generated from the repair output code from the input source code's CIL-representation.  This pull request is a hack I created to enable the dump of this information as I could not identify any existing mechanism that could give me the original AST to compare against.