### PR TITLE
fix attempt for issue #28 with --edit-script and --minimization --incoming-pop <file>

### DIFF
--- a/src/minimization.ml
+++ b/src/minimization.ml
@@ -280,7 +280,11 @@ let delta_debugging orig to_minimize node_map = begin
   let minimized = delta_set_to_list minimized_script in
   let min_rep = orig#copy() in
 
-  min_rep#construct_rep (None) (Some((script_to_pair_list minimized), node_map));
+  if !minimize_patch then
+    let script = lfoldl (fun acc str -> acc^" "^str) "" minimized in
+    min_rep#construct_rep (Some(script)) (None)
+  else 
+    min_rep#construct_rep (None) (Some((script_to_pair_list minimized), node_map));
 
   min_rep#output "Minimization_Files/minimized.c";
   let output_name = "minimized.diffscript" in


### PR DESCRIPTION
This turnin request contains a fix to a genprog issue where edits weren't being used with minimized when !minimize_patch is true.
Tested solution on minimal scenario identified in issue #28, maximal set provided by Joe Renzullo, and covered all combination of command line cases for `--minimization`, `--edit-script`, `--incoming-pop <file>` .

It looks good in my testing, but please note that I didn't do a full regression test... also note that my update mirrors a similar construct in `minimization.ml @ 201-205`

