### PR TITLE
New Features: ASLR Disabling, Minimization bug fix, Coverage per test

### DIFF
--- a/src/global.ml
+++ b/src/global.ml
@@ -566,6 +566,19 @@ let usage_function aligned usage_msg x =
   debug "usage: unknown option %s\n" x;
   Arg.usage aligned usage_msg; abort "usage"
 
+(* Utility function to run a command and return its results as a string (from PLEAC). *)
+let read_process command =
+  let buffer_size = 2048 in
+  let buffer = Buffer.create buffer_size in
+  let string = String.create buffer_size in
+  let in_channel = Unix.open_process_in command in
+  let chars_read = ref 1 in
+  while !chars_read <> 0 do
+    chars_read := input in_channel string 0 buffer_size;
+    Buffer.add_substring buffer string 0 !chars_read
+  done;
+  ignore (Unix.close_process_in in_channel);
+  Buffer.contents buffer
 
 (** Utility function to read 'command-line arguments' from a file.  This allows
     us to avoid the old 'ldflags' file hackery, etc. *)

--- a/src/main.ml
+++ b/src/main.ml
@@ -88,6 +88,10 @@ let _ =
                "X genome for oracle search, either string or binary file.";
 
                "--version", Arg.Set show_version, " print the version and exit";
+
+               "--disable-aslr", Arg.Set Rep.disable_aslr,
+               " Disable ASLR during test runtime";
+
              ]
 
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -52,6 +52,7 @@ open Printf
 open Global
 open Population
 
+let rep_out = ref "original"
 let representation = ref ""
 let time_at_start = Unix.gettimeofday ()
 let describe_machine = ref false
@@ -81,6 +82,8 @@ let _ =
 
                "--rep", Arg.Set_string representation, "X representation X (c,txt,java)" ;
 
+               "--orig-rep-out", Arg.Set_string rep_out, "X Output filename to which to print initial representation" ;
+
                "--oracle-genome", Arg.Set_string oracle_genome,
                "X genome for oracle search, either string or binary file.";
 
@@ -97,6 +100,7 @@ let _ =
 let process base ext (rep :('a,'b) Rep.representation) =
   (* load the rep, either from a cache or from source *)
   rep#load base;
+  rep#print_original_src !rep_out;
   rep#debug_info () ;
 
   (* load incoming population, if specified.  We no longer have to do this

--- a/src/minimization.ml
+++ b/src/minimization.ml
@@ -280,7 +280,11 @@ let delta_debugging orig to_minimize node_map = begin
   let minimized = delta_set_to_list minimized_script in
   let min_rep = orig#copy() in
 
-  min_rep#construct_rep (None) (Some((script_to_pair_list minimized), node_map));
+  if !minimize_patch then
+    let script = lfoldl (fun acc str -> acc^" "^str) "" minimized in
+    min_rep#construct_rep (Some(script)) (None)
+  else 
+    min_rep#construct_rep (None) (Some((script_to_pair_list minimized), node_map));
 
   min_rep#output "Minimization_Files/minimized.c";
   let output_name = "minimized.diffscript" in

--- a/src/rep.ml
+++ b/src/rep.ml
@@ -493,6 +493,8 @@ class type ['gene,'code] representation = object('self_type)
 
   method print_original_src : string -> unit
 
+  method system_aslr : string -> Unix.process_status
+
 end
 
 (** Test name to string *)
@@ -576,6 +578,8 @@ let atom_test_coverage = Hashtbl.create 255
 let sanity = ref "default"
 
 let ccfile = ref ""  (* path to code clone file *)
+
+let disable_aslr = ref false
 
 let _ =
   options := !options @
@@ -1248,6 +1252,12 @@ class virtual ['gene,'code] cachingRepresentation = object (self : ('gene,'code)
     | None -> []
   (**/**)
 
+  method system_aslr cmd =
+	let local_cmd = 
+	if not !disable_aslr then cmd
+	else "setarch "^(read_process "uname -m")^" -R "^(cmd) in
+    system local_cmd;
+    
 
   method print_original_src fname = 
     let original_filename = (fname) ^ if (!Global.extension <> "")

--- a/src/rep.ml
+++ b/src/rep.ml
@@ -490,6 +490,9 @@ class type ['gene,'code] representation = object('self_type)
 
       @return hashvalue for this variant.*)
   method hash : unit -> int
+
+  method print_original_src : string -> unit
+
 end
 
 (** Test name to string *)
@@ -1236,6 +1239,19 @@ class virtual ['gene,'code] cachingRepresentation = object (self : ('gene,'code)
     | Some(source_names) -> source_names
     | None -> []
   (**/**)
+
+
+  method print_original_src fname = 
+    let original_filename = (fname) ^ if (!Global.extension <> "")
+        then !Global.extension
+        else "" in
+      self#output_source original_filename ; 
+	(*  note from pdreiter:
+	   clearing already_sourced to ensure that the outputted file isn't removed 
+	   when cleanup () is called
+	*)
+    already_sourced := None ; 
+
 
   (** ignores the return values of the unix system calls it uses, namely [system]
       and [unlink], and thus will fail silently if they do *)


### PR DESCRIPTION
ASLR Disabling: During test runs, found some non-determinism in test results due to ASLR. Added a feature to genprog --disable-aslr which disables ASLR (implemented Linux-based genprog support only)
Minimization bug fix: from git branch minimization-edit-bugfix, stable fix for --minimization --edit-script issue #29 
Coverage per test: Coverage information is dumped per test --fault-path-per-test (negative coverage) and --fix-path-per-test (positive coverage) ; simpler than --coverage-per-test, which touched more code, but did not seem to output any file?